### PR TITLE
Update Makefile.in so cosign can be easily packaged

### DIFF
--- a/filters/apache2/Makefile.in
+++ b/filters/apache2/Makefile.in
@@ -56,7 +56,7 @@ mod_cosign.la: ${SRC}
 #   install the DSO file into the Apache installation
 #   and activate it in the Apache configuration
 install: all
-	$(APXS2) -i -a -n 'cosign' mod_cosign.la
+	$(APXS2) -i -a -S LIBEXECDIR=$(DESTDIR)$(LIBEXECDIR) -n 'cosign' mod_cosign.la
 
 #   cleanup
 clean:


### PR DESCRIPTION
The Makefile uses apxs to install the mod_cosign module, but it
doesn't support installing into $DESTDIR so it fails during RPM
packaging.  This commit simply overrides LIBEXECDIR to prepend
$DESTDIR as part of the apxs install stage.  If DESTDIR is undefined,
LIBEXECDIR is not changed.